### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
+[![Board Status](https://dev.azure.com/piotrapriasz/46ab9230-e7e0-4797-b5c6-17c10a70b152/c05114db-ab07-4e33-ae7c-cd33d11fb6f3/_apis/work/boardbadge/a358ac83-032d-425e-814f-46b12e9725b9)](https://dev.azure.com/piotrapriasz/46ab9230-e7e0-4797-b5c6-17c10a70b152/_boards/board/t/c05114db-ab07-4e33-ae7c-cd33d11fb6f3/Microsoft.RequirementCategory)
 # iDyCoin
 Decentralized application project for testing creating blockchain solutions with Solidity and Nethereum


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#2](https://dev.azure.com/piotrapriasz/46ab9230-e7e0-4797-b5c6-17c10a70b152/_workitems/edit/2). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.